### PR TITLE
Make sure sockets are closed once we're done

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ class LibRcon {
                         let str = buff.toString("utf-8", 12);
 
                         client.removeAllListeners();
+                        client.end();
                         resolve(str);
                     }
                 });


### PR DESCRIPTION
At the moment this library only closes connections on a timeout, meaning
that repeated invocations of `librcon.send()` will eventually exhaust
the available number of file system descriptors on a system.

This commit makes sure we half-close the socket (send a FIN packet) once
we're done.